### PR TITLE
Corregir redirección, actualizar Traefik y licencia

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Xabi
+Copyright (c) 2021 Club Celica España
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Club Celica España
+Copyright (c) 2021-2022 Club Celica España
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/dynamic.yml
+++ b/config/dynamic.yml
@@ -20,10 +20,6 @@ http:
       compress:
         excludedContentTypes:
           - text/event-stream
-    https-redirect:
-      redirectScheme:
-        scheme: https
-        permanent: true
     security:
       headers:
         accessControlAllowOriginList:

--- a/config/traefik.yml
+++ b/config/traefik.yml
@@ -12,6 +12,12 @@ api:
 entryPoints:
   web:
     address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
   websecure:
     address: ":443"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,6 @@ services:
       - /var/log/traefik:/var/log/traefik
     labels:
       traefik.enable: "false"
-      # Catch all HTTP requests
-      traefik.http.routers.app.rule: "HostRegexp(`{host:.+}`)"
-      traefik.http.routers.app.entrypoints: "web"
-      # Add middleware
-      traefik.http.routers.app.middlewares: "https-redirect@file"
 
 networks:
   wan:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.6.0
+    image: traefik:v2.6.1
     container_name: traefik
     domainname: clubcelica.es
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.5.4
+    image: traefik:v2.6.0
     container_name: traefik
     domainname: clubcelica.es
     restart: always


### PR DESCRIPTION
El cambio más importante corrige la redirección de HTTP a HTTPS. Después, se ha actualizado Traefik a la última versión estable disponible y por último, se ha actualizado la licencia.