### PR TITLE
Incluir plugin geoblock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugin/geoblock"]
+	path = plugin/geoblock
+	url = https://github.com/PascalMinder/geoblock.git

--- a/config/dynamic.yml
+++ b/config/dynamic.yml
@@ -20,6 +20,41 @@ http:
       forwardauth:
         address: http://bouncer-traefik:6085/api/v1/forwardAuth
         trustForwardHeader: true
+    geoblock:
+      plugin:
+        geoblock:
+          allowLocalRequests: true
+          logLocalRequests: false
+          logAllowedRequests: false
+          logApiRequests: true
+          api: "https://get.geojs.io/v1/ip/country/{ip}"
+          apiTimeoutMs: 750
+          cacheSize: 15
+          forceMonthlyUpdate: true
+          allowUnknownCountries: false
+          unknownCountryApiResponse: "nil"
+          countries:
+            - ES # Spain
+            - FR # France
+            - PT # Portugal
+            - AR # Argentina
+            - BO # Bolivia (Plurinational State of)
+            - CL # Chile
+            - CO # Colombia
+            - CR # Costa Rica
+            - DO # Dominican Republic (the)
+            - EC # Ecuador
+            - SV # El Salvador
+            - GT # Guatemala
+            - HN # Honduras
+            - NI # Nicaragua
+            - PA # Panama
+            - PY # Paraguay
+            - PE # Peru
+            - PR # Puerto Rico
+            - UY # Uruguay
+            - VE # Venezuela (Bolivarian Republic of)
+
     compression:
       compress:
         excludedContentTypes:

--- a/config/traefik.yml
+++ b/config/traefik.yml
@@ -20,11 +20,13 @@ entryPoints:
           permanent: true
       middlewares:
         - crowdsec-bouncer@file
+        - geoblock@file
   websecure:
     address: ":443"
     http:
       middlewares:
         - crowdsec-bouncer@file
+        - geoblock@file
 
 log:
   level: INFO
@@ -55,3 +57,8 @@ certificatesResolvers:
 
 global:
   sendAnonymousUsage: false
+  
+ experimental:
+  localPlugins:
+    geoblock:
+      moduleName: github.com/PascalMinder/geoblock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       # Traefik configuration files
       - ./config/traefik.yml:/etc/traefik/traefik.yml
       - ./config/dynamic.yml:/etc/traefik/dynamic.yml
+      # Traefik plugins
+      - ./plugin/geoblock:/plugins-local/src/github.com/PascalMinder/geoblock
       # SSL
       - ./acme:/acme
       # Logs


### PR DESCRIPTION
Incluido el plugin y las configuraciones necesarias para su funcionamiento.

Los países incluidos como permitidos son los que contienen los usuarios habituales o potenciales, aunque es probable que poco a poco haya que ir ajustando esta lista.