### PR TITLE
Habilitar HTTP/3

### DIFF
--- a/config/traefik.yml
+++ b/config/traefik.yml
@@ -27,6 +27,8 @@ entryPoints:
       middlewares:
         - crowdsec-bouncer@file
         - geoblock@file
+    http3:
+      advertisedPort: "443"
 
 log:
   level: INFO
@@ -59,6 +61,7 @@ global:
   sendAnonymousUsage: false
   
 experimental:
+  http3: true
   localPlugins:
     geoblock:
       moduleName: github.com/PascalMinder/geoblock


### PR DESCRIPTION
Estos cambios habilitan la posibilidad de usar el protocolo HTTP/3 en Traefik.

Closes #18 