### PR TITLE
Incluir dos nuevos países a la lista de permitidos

### DIFF
--- a/config/dynamic.yml
+++ b/config/dynamic.yml
@@ -35,9 +35,11 @@ http:
           unknownCountryApiResponse: "nil"
           countries:
             - ES # Spain
+            - US # United States of America (the)
             - AD # Andorra
             - FR # France
             - PT # Portugal
+            - IT # Italy
             - AR # Argentina
             - BO # Bolivia (Plurinational State of)
             - CL # Chile


### PR DESCRIPTION
Se permitirá el acceso desde Italia y los EE. UU.

El motivo principal de la inclusión de este último país es evitar que la araña de Google no pueda acceder al foro o a cualquiera de los futuros espacios del club, evitando así los problemas de indexación que esto supone.