### PR TITLE
Actualizar Traefik y GeoBlock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.9.5
+    image: traefik:v2.9.6
     container_name: traefik
     domainname: clubcelica.es
     restart: always


### PR DESCRIPTION
Actualizados ambos proyectos a las últimas versiones estables disponibles:

- [Traefik v2.9.6](https://github.com/traefik/traefik/releases/tag/v2.9.6)
- [GeoBlock SHA 3ffcf3f113](https://github.com/PascalMinder/geoblock/tree/3ffcf3f11334e62690f0a87867c81c3a14c3a539)