### PR TITLE
Actualizar Traefik y GeoBlock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.10.1
+    image: traefik:v2.11.0
     container_name: traefik
     domainname: clubcelica.es
     restart: always


### PR DESCRIPTION
Actualizados ambos proyectos a las últimas versiones estables disponibles:

- [Traefik v2.11.0](https://github.com/traefik/traefik/releases/tag/v2.11.0)
- [GeoBlock SHA da9092c](https://github.com/PascalMinder/geoblock/tree/da9092c673786441b40aa762fbc323bbbd18132b)